### PR TITLE
Output parameters

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -196,31 +196,34 @@ int main(int argc, char* argv[]) {
         useInt64 = (std::find(result.begin(), result.end(), "64") != result.end());
     }
 
-    std::cout << "Column size in KB,Data type,Time in ns" << std::endl;
+    auto cached_str = cache ? "Cached" : "Uncached";
+    auto thread_count_str = std::to_string(thread_count) + " threads";
+
+    std::cout << "Column size in KB,Data type,Time in ns,Cache,Thread Count" << std::endl;
     for (auto size: DB_SIZES){
         std::cerr << "benchmarking " << (size / 1024.0f) << " KiB" << std::endl;
         if (useInt8) {
             auto int8_time = benchmark<std::int8_t>(size, col_count, thread_count, iterations, cache, randomInit);
             for (long long int time: int8_time)
-                std::cout << (size / 1024.0f) << ",int8," << time << std::endl;
+                std::cout << (size / 1024.0f) << ",int8," << time << "," << cached_str << "," << thread_count_str << std::endl;
         }
 
         if (useInt16) {
             auto int16_time = benchmark<std::int16_t>(size, col_count, thread_count, iterations, cache, randomInit);
             for (long long int time: int16_time)
-                std::cout << (size / 1024.0f) << ",int16," << time << std::endl;
+                std::cout << (size / 1024.0f) << ",int16," << time << "," << cached_str << "," << thread_count_str << std::endl;
         }
 
         if (useInt32) {
             auto int32_time = benchmark<std::int32_t>(size, col_count, thread_count, iterations, cache, randomInit);
             for (long long int time: int32_time)
-                std::cout << (size / 1024.0f) << ",int32," << time << std::endl;
+                std::cout << (size / 1024.0f) << ",int32," << time << "," << cached_str << "," << thread_count_str << std::endl;
         }
 
         if (useInt64) {
             auto int64_time = benchmark<std::int64_t>(size, col_count, thread_count, iterations, cache, randomInit);
             for (long long int time: int64_time)
-                std::cout << (size / 1024.0f) << ",int64," << time << std::endl;
+                std::cout << (size / 1024.0f) << ",int64," << time << "," << cached_str << "," << thread_count_str << std::endl;
         }
     }
 

--- a/generate_figures.py
+++ b/generate_figures.py
@@ -68,7 +68,7 @@ def process_file(filename, show_variance):
         else:
             plt.ylim(ymin=0, ymax=20)
     else:
-        plt.ylim(ymin=0, ymax=100)
+        plt.ylim(ymin=0, ymax=200)
 
     # show cache sizes of L1, L2 and L3
     if system_type == 'intel':


### PR DESCRIPTION
Thread count and whether or not the vector was cached are now printed to the csv. In addition, the figure script takes arbitrary experiment conditions and groups them accordingly. What this means is that we can concatenate .CSVs of different experiments and display them in the same graph. To illustrate, here's an example CSV: 
```
Column size in KB,Data type,Time in ns,Cache,Thread Count
8,int8,12905,Cached,2 threads
8,int8,12905,Cached,8 threads
8,int16,12905,Cached,2 threads
8,int16,12905,Cached,8 threads
```

Our script will detect that there are 4 groups: `int8, 2 threads`, `int8, 8 threads`, `int16, 2 threads` and `int16, 8 threads` and therefore plot 4 different lines with these groups as labels. There is a parameter `Cache`, but since it's the same throughout the CSV, it's dropped from the plot.