### PR TITLE
Fix the number of CPUs (Intel)

### DIFF
--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -24,10 +24,10 @@ else
   FOLDER="intel-results"
   SMT_CONFIGURATIONS=2
   SMT_SETTINGS=(1 2)
-  THREAD_COUNTS=(8 16)
+  THREAD_COUNTS=(15 30)
   # on the rapa.eaalab machine, these are the NUMA node0 CPUs
-  CORE_BINDINGS=("`seq -s, 0 1 8`"
-                 "`seq -s, 0 1 8`,`seq -s, 120 8 134`")
+  CORE_BINDINGS=("`seq -s, 0 1 15`"
+                 "`seq -s, 0 1 14`,`seq -s, 120 1 134`")
   MEMNODE=0
   PREFETCHER_SETTINGS=(1 0) # 0 means off, 1 means on (no other options available)
 

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -26,7 +26,7 @@ else
   SMT_SETTINGS=(1 2)
   THREAD_COUNTS=(15 30)
   # on the rapa.eaalab machine, these are the NUMA node0 CPUs
-  CORE_BINDINGS=("`seq -s, 0 1 15`"
+  CORE_BINDINGS=("`seq -s, 0 1 14`"
                  "`seq -s, 0 1 14`,`seq -s, 120 1 134`")
   MEMNODE=0
   PREFETCHER_SETTINGS=(1 0) # 0 means off, 1 means on (no other options available)


### PR DESCRIPTION
Truncated output of `lscpu` below:
```
Carl.Goedecken@rapa:~> lscpu
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                240
On-line CPU(s) list:   0-239
Thread(s) per core:    2
Core(s) per socket:    15
Socket(s):             8
NUMA node(s):          8
...
Model name:            Intel(R) Xeon(R) CPU E7-8890 v2 @ 2.80GHz
...
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              38400K
NUMA node0 CPU(s):     0-14,120-134
NUMA node1 CPU(s):     15-29,135-149
...
```