### PR TITLE
Use main thread as last thread

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -135,12 +135,13 @@ void benchmark(size_t colSize, int colCount, int threadCount, int iterations, bo
             startIndex = endIndex;
         }
 
-        threadFlag = true;
 
         // run threadFunc on main thread
         int j = threadCount - 1;
         size_t endIndex = startIndex + partLength + (j < overhang ? 1 : 0);
-        threadFunc<T>(ref(attributeVector), colCount, startIndex, endIndex, threadCount - 1);
+
+        threadFlag = true;
+        threadFunc<T>(ref(attributeVector), colCount, startIndex, endIndex, j);
 
         for (thread *thread: threads) {
             (*thread).join();

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -127,14 +127,20 @@ void benchmark(size_t colSize, int colCount, int threadCount, int iterations, bo
             clearCache();
         }
 
-        for (int j = 0; j < threadCount; j++) {
+        for (int j = 0; j < threadCount - 1; j++) {
             size_t endIndex = startIndex + partLength + (j < overhang ? 1 : 0);
             auto threadInstance = new thread(threadFunc<T>, ref(attributeVector), colCount, startIndex,
                     endIndex, j);
             threads.push_back(threadInstance);
             startIndex = endIndex;
         }
+
         threadFlag = true;
+
+        // run threadFunc on main thread
+        int j = threadCount - 1;
+        size_t endIndex = startIndex + partLength + (j < overhang ? 1 : 0);
+        threadFunc<T>(ref(attributeVector), colCount, startIndex, endIndex, threadCount - 1);
 
         for (thread *thread: threads) {
             (*thread).join();


### PR DESCRIPTION
The times do not differ significantly:
```
~/tuk/benchmark> sudo numactl --physcpubind=15,16,17,18,19,20 --membind=1 ./benchmark --column-count 1 --thread-count 6 --cache --data-types 64
Column size in KB,Data type,Time in ns,Cache,Thread Count
benchmarking 4.1943e+06 KiB
4.1943e+06,int64,108231765,Cached,6 threads
4.1943e+06,int64,106952435,Cached,6 threads
4.1943e+06,int64,107500421,Cached,6 threads
4.1943e+06,int64,106339351,Cached,6 threads
4.1943e+06,int64,106980441,Cached,6 threads
4.1943e+06,int64,107142221,Cached,6 threads
```
New version:
```
~/tuk/benchmark> sudo numactl --physcpubind=15,16,17,18,19,20 --membind=1 ./benchmark --column-count 1 --thread-count 6 --cache --data-types 64
Column size in KB,Data type,Time in ns,Cache,Thread Count
benchmarking 4.1943e+06 KiB
4.1943e+06,int64,106887588,Cached,6 threads
4.1943e+06,int64,106914419,Cached,6 threads
4.1943e+06,int64,107303159,Cached,6 threads
4.1943e+06,int64,106604894,Cached,6 threads
4.1943e+06,int64,109119420,Cached,6 threads
4.1943e+06,int64,106789241,Cached,6 threads
```