### PR TITLE
Downgrade mininum requred CMake version

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.5)
 project(benchmark)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
This is due to CMake 3.10 being unavailable in the repositories on the server.
Somehow, the manually installed version disappeared.