### PR TITLE
Implement runs inside threads

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -34,7 +34,7 @@ static const size_t DB_SIZES[] = {8 * KiB, 16 * KiB, 32 * KiB, 48 * KiB, 64 * Ki
                                     64 * MiB, 128 * MiB, 256 * MiB, 1 * GiB, 4 * GiB};
 #endif
 
-static const float ITERATIONS_FACTOR = 0.01f;
+static const float ITERATIONS_FACTOR = 100f;
 
 vector<string> parseDataTypes(const string &dataTypes) {
     vector<string> result;

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -122,36 +122,24 @@ void benchmark(size_t colSize, int colCount, int threadCount, int iterations, bo
     // Cache clearing, do one dry run after
     if (!cache) {
         clearCache();
+    }
 
-        size_t startIndex = 0;
-        for (int i = 0; i < threadCount; i++) {
-            size_t endIndex = startIndex + partLength + (i < overhang ? 1 : 0);
-            auto threadInstance = new thread(threadFunc<T>, ref(attributeVector), colCount, startIndex,
-                                             endIndex, i, iterations);
-            threads.push_back(threadInstance);
-            startIndex = endIndex;
-        }
-        threadFlag = true;
-
-        for (thread *thread: threads) {
-            (*thread).join();
-        }
-
-        for (int j = 0; j < threadCount - 1; j++) {
-            size_t endIndex = startIndex + partLength + (j < overhang ? 1 : 0);
-            auto threadInstance = new thread(threadFunc<T>, ref(attributeVector), colCount, startIndex,
-                    endIndex, j);
-            threads.push_back(threadInstance);
-            startIndex = endIndex;
-        }
-
-
-        // run threadFunc on main thread
-        int j = threadCount - 1;
+    size_t startIndex = 0;
+    for (int j = 0; j < threadCount - 1; j++) {
         size_t endIndex = startIndex + partLength + (j < overhang ? 1 : 0);
+        auto threadInstance = new thread(threadFunc<T>, ref(attributeVector), colCount, startIndex,
+                                         endIndex, j, iterations);
+        threads.push_back(threadInstance);
+        startIndex = endIndex;
+    }
 
-        threadFlag = true;
-        threadFunc<T>(ref(attributeVector), colCount, startIndex, endIndex, j, iterations);
+
+    // run threadFunc on main thread
+    int j = threadCount - 1;
+    size_t endIndex = startIndex + partLength + (j < overhang ? 1 : 0);
+
+    threadFlag = true;
+    threadFunc<T>(ref(attributeVector), colCount, startIndex, endIndex, j, iterations);
 
     for (thread *thread: threads) {
         (*thread).join();

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -86,7 +86,6 @@ template <class T>
 void threadFunc(vector<T>& elements, int colCount, size_t startIndex, size_t endIndex, int threadId, int iterations){
     while (!threadFlag)
         ;
-    vector<long long int> times;
     for (int i = 0; i < iterations; i++) {
         auto start = chrono::high_resolution_clock::now();
         for (size_t j = startIndex; j < endIndex; j++) {

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[]) {
     for (auto size: DB_SIZES){
         cerr << "benchmarking " << (size / 1024.0f) << " KiB" << endl;
 
-        int mIterations = iterations == -1 ? max(1, (int) (ITERATIONS_FACTOR * size)) : iterations;
+        int mIterations = iterations == -1 ? max(1, (int) (1 / ITERATIONS_FACTOR / size * 8 * KiB)) : iterations;
 
         if (useInt8) {
             benchmark<int8_t>(size, colCount, threadCount, mIterations, cache, randomInit);

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -189,7 +189,7 @@ int main(int argc, char* argv[]) {
     Flags flags;
     flags.Var(colCount, 'c', "column-count", 1, "Number of columns to use");
     flags.Var(threadCount, 't', "thread-count", 1, "Number of threads");
-    flags.Var(iterations, 'i', "iterations", -1, "Number of iterations");
+    flags.Var(iterations, 'i', "iterations", 0, "Number of iterations");
     flags.Var(dataTypes, 'd', "data-types", string(""), "Comma-separated list of types (e.g. 8 for int8_t)");
     flags.Bool(cache, 'C', "cache", "Whether to enable the use of caching", "Choose one of them");
     flags.Bool(noCache, 'N', "nocache", "Whether to disable the use of caching", "Choose one of them");
@@ -226,7 +226,8 @@ int main(int argc, char* argv[]) {
     for (auto size: DB_SIZES){
         cerr << "benchmarking " << (size / 1024.0f) << " KiB" << endl;
 
-        int mIterations = iterations == -1 ? max(1, (int) (1 / ITERATIONS_FACTOR / size * 8 * KiB)) : iterations;
+        // For smallest size, iterations will be 1 / factor, e.g. 1/0.01 = 100. For double the size half of that etc.
+        int mIterations = iterations == 0 ? max(1, (int) (1 / ITERATIONS_FACTOR / size * DB_SIZES[0])) : iterations;
 
         if (useInt8) {
             benchmark<int8_t>(size, colCount, threadCount, mIterations, cache, randomInit);


### PR DESCRIPTION
Runs to be averaged are done inside threads to reduce overhead from syncing threadFlag and some other things on very small vectors. Related to that, the number of runs (if no parameter is specified) defaults to `100 / (size / 8KiB)`, so the smallest size will do 100 iterations, the second smallest one 50 etc. I'm still returning one time for each iteration so that we can use error bars.

Cache Clearing is kind of irrelevant now, so we might remove it? Feedback welcome!  
Edit: Cache clearing has just been removed, from code and bash script